### PR TITLE
Default to root project properties.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,6 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
 buildscript {
     repositories {
         jcenter()
@@ -12,12 +15,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 23)
+    buildToolsVersion safeExtGet('buildToolsVersion', '23.0.1')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 22)
         versionCode 1
         versionName "0.2.0"
     }


### PR DESCRIPTION
Added safeExtGet to build.gradle and wrapped compileSdkVersion, buildToolsVersion, minSdkVersion & targetSdkVersion accordingly.